### PR TITLE
Weak referenced Identity cache in the CurrentUser class

### DIFF
--- a/src/CurrentUser.php
+++ b/src/CurrentUser.php
@@ -229,6 +229,10 @@ final class CurrentUser
     public function setTemporaryIdentity(IdentityInterface $identity): void
     {
         $this->temporaryIdentity = WeakReference::create($identity);
+        unset($identity);
+        if ($this->temporaryIdentity->get() === null) {
+            throw new \Exception('No reference.');
+        }
     }
 
     public function clearTemporaryIdentity(): void

--- a/src/CurrentUser.php
+++ b/src/CurrentUser.php
@@ -77,6 +77,7 @@ final class CurrentUser
      */
     public function getIdentity(): IdentityInterface
     {
+        /** @var IdentityInterface|null $identity */
         $identity = ($this->temporaryIdentity !== null ? $this->temporaryIdentity->get() : null)
             ?? ($this->identity !== null ? $this->identity->get() : null);
 

--- a/tests/CurrentUserTest.php
+++ b/tests/CurrentUserTest.php
@@ -215,7 +215,8 @@ final class CurrentUserTest extends TestCase
             $this->createEventDispatcher(),
             $this->createSession(['__auth_id' => $id])
         );
-        $currentUser->setTemporaryIdentity(new MockIdentity('temp-id'));
+        $temporaryIdentity = new MockIdentity('temp-id');
+        $currentUser->setTemporaryIdentity($temporaryIdentity);
         $currentUser->clearTemporaryIdentity();
 
         self::assertSame($identity, $currentUser->getIdentity());
@@ -424,7 +425,7 @@ final class CurrentUserTest extends TestCase
         self::assertSame('from-repository', $currentUser->getIdentity()->getId());
     }
 
-    public function testWeakTemporaryIdentityCacheSideEffect(): void
+    public function testWeakTemporaryIdentityCacheArgumentWithoutReference(): void
     {
         $currentUser = new CurrentUser(
             $this->createIdentityRepository(),
@@ -432,11 +433,10 @@ final class CurrentUserTest extends TestCase
             $this->createSession()
         );
 
+        $this->expectException(\Exception::class);
+
         // Identity without refs
         $currentUser->setTemporaryIdentity(new MockIdentity('temporary'));
-
-        self::assertNotSame('temporary', $currentUser->getIdentity()->getId());
-        self::assertInstanceOf(GuestIdentity::class, $currentUser->getIdentity());
     }
 
     public function testWeakIdentityCache(): void

--- a/tests/Mock/MockIdentityRepository.php
+++ b/tests/Mock/MockIdentityRepository.php
@@ -40,4 +40,9 @@ class MockIdentityRepository implements IdentityRepositoryInterface
     {
         $this->withException = true;
     }
+
+    public function setIdentity(?IdentityInterface $identity = null): void
+    {
+        $this->identity = $identity;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed issues  | #2 

An example of how you can store the cache using WeakReference