### PR TITLE
Make GuestIdentity extensible

### DIFF
--- a/src/GuestIdentity.php
+++ b/src/GuestIdentity.php
@@ -9,9 +9,9 @@ use Yiisoft\Auth\IdentityInterface;
 /**
  * Implementation of the identity interface for a guest non-authenticated user.
  */
-final class GuestIdentity implements IdentityInterface
+class GuestIdentity implements IdentityInterface
 {
-    public function getId(): ?string
+    final public function getId(): ?string
     {
         return null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #25

Makes the `GuestIdentity` NOT final, but the `getId()` method final. It could be expanded if necessary. I think that in this case extension would be the right solution.
