### PR TITLE
Remove CookieLoginIdentityInterface::shouldLoginByCookie()

### DIFF
--- a/src/Login/Cookie/CookieLoginIdentityInterface.php
+++ b/src/Login/Cookie/CookieLoginIdentityInterface.php
@@ -44,13 +44,4 @@ interface CookieLoginIdentityInterface extends IdentityInterface
      * @see getCookieLoginKey()
      */
     public function validateCookieLoginKey(string $key): bool;
-
-    /**
-     * Whether to add a cookie with login key to response.
-     *
-     * @return bool Whether to add a cookie.
-     *
-     * @see getCookieLoginKey()
-     */
-    public function shouldLoginByCookie(): bool;
 }

--- a/src/Login/Cookie/CookieLoginMiddleware.php
+++ b/src/Login/Cookie/CookieLoginMiddleware.php
@@ -71,14 +71,11 @@ final class CookieLoginMiddleware implements MiddlewareInterface
         $response = $handler->handle($request);
         $guestAfterHandle = $this->currentUser->isGuest();
 
-        if ($guestBeforeHandle && !$guestAfterHandle) {
+        if ($this->forceAddCookie && $guestBeforeHandle && !$guestAfterHandle) {
             $identity = $this->currentUser->getIdentity();
 
-            if (
-                $identity instanceof CookieLoginIdentityInterface &&
-                ($this->forceAddCookie || $identity->shouldLoginByCookie())
-            ) {
-                return $this->cookieLogin->addCookie($identity, $response);
+            if ($identity instanceof CookieLoginIdentityInterface) {
+                $response = $this->cookieLogin->addCookie($identity, $response);
             }
         }
 

--- a/tests/Support/CookieLoginIdentity.php
+++ b/tests/Support/CookieLoginIdentity.php
@@ -11,7 +11,6 @@ final class CookieLoginIdentity implements CookieLoginIdentityInterface
     public const ID = '42';
     public const KEY_CORRECT = 'auto-login-key-correct';
     public const KEY_INCORRECT = 'auto-login-key-incorrect';
-    public bool $rememberMe = false;
 
     public function getCookieLoginKey(): string
     {
@@ -26,10 +25,5 @@ final class CookieLoginIdentity implements CookieLoginIdentityInterface
     public function getId(): ?string
     {
         return self::ID;
-    }
-
-    public function shouldLoginByCookie(): bool
-    {
-        return $this->rememberMe;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
