### PR TITLE
Add optional parameter `$duration` to `CookieLogin::addCookie()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Chg #58: Raise the minimum version of PHP to 8.0 and did refactoring using the features of it (@xepozz, @rustamwin)
 - Chg #58: Raise version of `yiisoft/access` to `^2.0` (@rustamwin)
 - Enh #83: Allow to create a session cookie via `CookieLogin` (@rustamwin)
+- New #86: Add optional parameter `$duration` to `CookieLogin::addCookie()` (@vjik)
 
 ## 2.0.0 February 15, 2023
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The package handles user-related functionality:
 The package could be installed with composer:
 
 ```shell
-composer require yiisoft/user --prefer-dist
+composer require yiisoft/user
 ```
 
 ## General usage

--- a/src/Login/Cookie/CookieLogin.php
+++ b/src/Login/Cookie/CookieLogin.php
@@ -48,17 +48,26 @@ final class CookieLogin
      *
      * @param CookieLoginIdentityInterface $identity The cookie login identity instance.
      * @param ResponseInterface $response Response for adding auto-login cookie.
+     * @param DateInterval|null|false $duration Interval until the auto-login cookie expires. If it is null it means
+     * the auto-login cookie is session cookie that expires when browser is closed. If it is false (by default) will be
+     * used default value of duration.
      *
      * @throws JsonException If an error occurs during JSON encoding of the cookie value.
      *
      * @return ResponseInterface Response with added auto-login cookie.
      */
-    public function addCookie(CookieLoginIdentityInterface $identity, ResponseInterface $response): ResponseInterface
+    public function addCookie(
+        CookieLoginIdentityInterface $identity,
+        ResponseInterface $response,
+        DateInterval|null|false $duration = false,
+    ): ResponseInterface
     {
+        $duration = $duration === false ? $this->duration : $duration;
+
         $data = [$identity->getId(), $identity->getCookieLoginKey()];
 
-        if ($this->duration !== null) {
-            $expires = (new DateTimeImmutable())->add($this->duration);
+        if ($duration !== null) {
+            $expires = (new DateTimeImmutable())->add($duration);
             $data[] = $expires->getTimestamp();
         } else {
             $expires = null;

--- a/src/Login/Cookie/CookieLogin.php
+++ b/src/Login/Cookie/CookieLogin.php
@@ -48,7 +48,7 @@ final class CookieLogin
      *
      * @param CookieLoginIdentityInterface $identity The cookie login identity instance.
      * @param ResponseInterface $response Response for adding auto-login cookie.
-     * @param DateInterval|null|false $duration Interval until the auto-login cookie expires. If it is null it means
+     * @param DateInterval|false|null $duration Interval until the auto-login cookie expires. If it is null it means
      * the auto-login cookie is session cookie that expires when browser is closed. If it is false (by default) will be
      * used default value of duration.
      *
@@ -60,8 +60,7 @@ final class CookieLogin
         CookieLoginIdentityInterface $identity,
         ResponseInterface $response,
         DateInterval|null|false $duration = false,
-    ): ResponseInterface
-    {
+    ): ResponseInterface {
         $duration = $duration === false ? $this->duration : $duration;
 
         $data = [$identity->getId(), $identity->getCookieLoginKey()];

--- a/tests/Login/Cookie/CookieLoginTest.php
+++ b/tests/Login/Cookie/CookieLoginTest.php
@@ -87,4 +87,40 @@ final class CookieLoginTest extends TestCase
             $response->getHeaderLine('Set-Cookie'),
         );
     }
+
+    public function dataAddCookieWithCustomDuration(): array
+    {
+        return [
+            'false' => [
+                '#testName=%5B%2242%22%2C%22auto-login-key-correct%22%2C[0-9]{10}%5D; Expires=.*?; Max-Age=604800; Path=/; Secure; HttpOnly; SameSite=Lax#',
+                false,
+            ],
+            'null' => [
+                '#testName=%5B%2242%22%2C%22auto-login-key-correct%22%2C0%5D; Path=/; Secure; HttpOnly; SameSite=Lax#',
+                null,
+            ],
+            'p1d' => [
+                '#testName=%5B%2242%22%2C%22auto-login-key-correct%22%2C[0-9]{10}%5D; Expires=.*?; Max-Age=86400; Path=/; Secure; HttpOnly; SameSite=Lax#',
+                new DateInterval('P1D'),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataAddCookieWithCustomDuration
+     */
+    public function testAddCookieWithCustomDuration(string $expectedRegExp, DateInterval|null|false $duration): void
+    {
+        $cookieLogin = (new CookieLogin(new DateInterval('P1W')))->withCookieName('testName');
+
+        $identity = new CookieLoginIdentity();
+
+        $response = new Response();
+        $response = $cookieLogin->addCookie($identity, $response, $duration);
+
+        $this->assertMatchesRegularExpression(
+            $expectedRegExp,
+            $response->getHeaderLine('Set-Cookie'),
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #85