### PR TITLE
Fix #101: Rename `UserAuth` to `WebAuth`, mark `UserAuth` as deprecated, add `ApiAuth` authentication method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2.1 under development
 
-- no changes in this release.
+- Chg #101: Rename `UserAuth` to `WebAuth`, mark `UserAuth` as deprecated (@olegbaturin)
+- Enh #101: Add `ApiAuth` authentication method (@olegbaturin)
 
 ## 2.2.0 May 07, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.2.1 under development
 
 - Chg #101: Rename `UserAuth` to `WebAuth`, mark `UserAuth` as deprecated (@olegbaturin)
-- Enh #101: Add `ApiAuth` authentication method (@olegbaturin)
+- New #101: Add `ApiAuth` authentication method (@olegbaturin)
 
 ## 2.2.0 May 07, 2024
 

--- a/README.md
+++ b/README.md
@@ -192,26 +192,14 @@ the state at every request. For this purpose, you can use the `clear()` method.
 
 ### Authentication methods
 
-This package provides two authentication methods, `Yiisoft\User\Method\WebAuth` and `Yiisoft\User\Method\ApiAuth`, that implement `Yiisoft\Auth\AuthenticationMethodInterface`. Both can be provided to the `Yiisoft\Auth\Middleware\Authentication` middleware as authentication method.
+This package provides two authentication methods, `WebAuth` and `ApiAuth`, that implement the `Yiisoft\Auth\AuthenticationMethodInterface`. Both can be provided to the `Yiisoft\Auth\Authentication` middleware as authentication method.
 
 #### WebAuth
 
-`Yiisoft\User\Method\WebAuth` is used to authenticate users in the classic web applications.
-If authentication is failed, it creates a new instance of the response from the `Yiisoft\Auth\Middleware\Authentication::authenticationFailureHandler`, and adds a `Location` header with a temporary redirect to the authentication URL, by default `/login`.
+`WebAuth` is used to authenticate users in the classic web applications.
+If authentication is failed, it creates a new instance of the response and adds a `Location` header with a temporary redirect to the authentication URL, by default `/login`.
 
-You can change this behavior through the parameter `authUrl` of the `yiisoft/user` package configuration
-
-`config/web/params.php`:
-
-```php
-return [
-    'yiisoft/user' => [
-        'authUrl' => '/auth',
-    ],
-];
-```
-
-or by calling `Yiisoft\User\Method\WebAuth::withAuthUrl()` method
+You can change authentication URL by calling `WebAuth::withAuthUrl()` method:
 
 ```php
 use Yiisoft\User\Method\WebAuth;
@@ -222,38 +210,38 @@ $authenticationMethod = new WebAuth();
 $authenticationMethod = $authenticationMethod->withAuthUrl('/auth');
 ```
 
-Class `Yiisoft\User\Method\WebAuth` is configured as default implementation of `Yiisoft\Auth\AuthenticationMethodInterface`.
+or in the DI container:
 
-`config/web/di/auth.php`:
-
+>[yiisoft/di](https://github.com/yiisoft/di) configuration example
 ```php
-use Yiisoft\Auth\AuthenticationMethodInterface;
-use Yiisoft\User\Method\WebAuth;
-
+// config/web/di/auth.php
 return [
-    AuthenticationMethodInterface::class => WebAuth::class,
+    WebAuth::class => [
+        'withAuthUrl()' => ['/auth'],
+    ],
 ];
 ```
+
+or through the parameter `authUrl` of the `yiisoft/user` config group, [yiisoft/config](https://github.com/yiisoft/config) package must be installed:
+
+```php
+// config/web/params.php
+return [
+    'yiisoft/user' => [
+        'authUrl' => '/auth',
+    ],
+];
+```
+
+In case the application is used along with the [yiisoft/config](https://github.com/yiisoft/config), the package is [configured](./config/di-web.php)
+automatically to use `WebAuth` as default implementation of `Yiisoft\Auth\AuthenticationMethodInterface`.
 
 #### ApiAuth
 
-`Yiisoft\User\Method\ApiAuth` is used to authenticate users in the API clients.
+`ApiAuth` is used to authenticate users in the API clients.
 If authentication is failed, it returns the response from the `Yiisoft\Auth\Middleware\Authentication::authenticationFailureHandler` handler.
 
-To use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI container configuration
-
-`config/web/di/auth.php`:
-
-```php
-use Yiisoft\Auth\AuthenticationMethodInterface;
-use Yiisoft\User\Method\ApiAuth;
-
-return [
-    AuthenticationMethodInterface::class => ApiAuth::class,
-];
-```
-
-or provide `Yiisoft\User\Method\ApiAuth` instance to the `Yiisoft\Auth\Middleware\Authentication` middleware
+To use `ApiAuth` as an authentication method, you need or provide the `ApiAuth` instance to the `Yiisoft\Auth\Middleware\Authentication` middleware
 
 ```php
 use Yiisoft\Auth\Middleware\Authentication;
@@ -265,6 +253,19 @@ $middleware = new Authentication(
     $authenticationMethod,
     $responseFactory // PSR-17 ResponseFactoryInterface
 );
+```
+
+of to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI container configuration:
+
+>[yiisoft/di](https://github.com/yiisoft/di) configuration example
+```php
+// config/web/di/auth.php
+use Yiisoft\Auth\AuthenticationMethodInterface;
+use Yiisoft\User\Method\ApiAuth;
+
+return [
+    AuthenticationMethodInterface::class => ApiAuth::class,
+];
 ```
 
 For more information about the authentication middleware and authentication methods, see the [yiisoft/auth](https://github.com/yiisoft/auth).

--- a/README.md
+++ b/README.md
@@ -192,40 +192,44 @@ the state at every request. For this purpose, you can use the `clear()` method.
 
 ### Authentication methods
 
-This package provides two authentication methods, `ApiAuth` and `WebAuth`, that implement `AuthenticationMethodInterface`. Both can be provided to the `Yiisoft\Auth\Middleware\Authentication` middleware as authentication method.
+This package provides two authentication methods, `Yiisoft\User\Method\WebAuth` and `Yiisoft\User\Method\ApiAuth`, that implement `Yiisoft\Auth\AuthenticationMethodInterface`. Both can be provided to the `Yiisoft\Auth\Middleware\Authentication` middleware as authentication method.
 
 #### WebAuth
 
 `Yiisoft\User\Method\WebAuth` is used to authenticate users in the classic web applications.
-If authentication is failed, it creates a new instance of the response from the `Authentication::authenticationFailureHandler`, and adds a `Location` header with a temporary redirect to the authentication URL, by default `/login`.
+If authentication is failed, it creates a new instance of the response from the `Yiisoft\Auth\Middleware\Authentication::authenticationFailureHandler`, and adds a `Location` header with a temporary redirect to the authentication URL, by default `/login`.
 
 You can change this behavior through the parameter `authUrl` of the `yiisoft/user` package configuration
 
 `config/web/params.php`:
 
-```
+```php
 return [
     'yiisoft/user' => [
         'authUrl' => '/auth',
-        ],
     ],
 ];
 ```
 
 or by calling `WebAuth::withAuthUrl()` method
 
-```
-$authenticationMethod = new \Yiisoft\User\Method\WebAuth();
+```php
+use Yiisoft\User\Method\WebAuth;
+
+$authenticationMethod = new WebAuth();
 
 // Returns a new instance with the specified authentication URL.
 $authenticationMethod = $authenticationMethod->withAuthUrl('/auth');
 ```
 
-Class `Yiisoft\User\Method\WebAuth` is configured as default implementation of `AuthenticationMethodInterface`.
+Class `Yiisoft\User\Method\WebAuth` is configured as default implementation of `Yiisoft\Auth\AuthenticationMethodInterface`.
 
 `config/web/di/auth.php`:
 
-```
+```php
+use Yiisoft\Auth\AuthenticationMethodInterface;
+use Yiisoft\User\Method\WebAuth;
+
 return [
     AuthenticationMethodInterface::class => WebAuth::class,
 ];
@@ -236,11 +240,14 @@ return [
 `Yiisoft\User\Method\ApiAuth` is used to authenticate users in the API clients.
 If authentication is failed, it returns the response from the `Authentication::authenticationFailureHandler()` method.
 
-In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `AuthenticationMethodInterface` in the DI configuration
+In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI configuration
 
 `config/web/di/auth.php`:
 
-```
+```php
+use Yiisoft\Auth\AuthenticationMethodInterface;
+use Yiisoft\User\Method\ApiAuth;
+
 return [
     AuthenticationMethodInterface::class => ApiAuth::class,
 ];
@@ -248,10 +255,13 @@ return [
 
 or provide `Yiisoft\User\Method\ApiAuth` instance to the `Yiisoft\Auth\Middleware\Authentication` middleware
 
-```
-$authenticationMethod = new \Yiisoft\User\Method\ApiAuth();
+```php
+use Yiisoft\Auth\Middleware\Authentication;
+use Yiisoft\User\Method\ApiAuth;
 
-$middleware = new \Yiisoft\Auth\Middleware\Authentication(
+$authenticationMethod = new ApiAuth();
+
+$middleware = new Authentication(
     $authenticationMethod,
     $responseFactory // PSR-17 ResponseFactoryInterface
 );

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ If authentication is failed, it creates a new instance of the response from the 
 
 You can change this behavior through the parameter `authUrl` of the `yiisoft/user` package configuration
 
+`config/web/params.php`:
+
 ```
 return [
     'yiisoft/user' => [
@@ -221,6 +223,8 @@ $authenticationMethod = $authenticationMethod->withAuthUrl('/auth');
 
 Class `Yiisoft\User\Method\WebAuth` is configured as default implementation of `AuthenticationMethodInterface`.
 
+`config/web/di/auth.php`:
+
 ```
 return [
     AuthenticationMethodInterface::class => WebAuth::class,
@@ -233,6 +237,8 @@ return [
 If authentication is failed, it returns the response from the `Authentication::authenticationFailureHandler()` method.
 
 In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `AuthenticationMethodInterface` in the DI configuration
+
+`config/web/di/auth.php`:
 
 ```
 return [

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ return [
 `Yiisoft\User\Method\ApiAuth` is used to authenticate users in the API clients.
 If authentication is failed, it returns the response from the `Yiisoft\Auth\Middleware\Authentication::authenticationFailureHandler` handler.
 
-In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI configuration
+In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI container configuration
 
 `config/web/di/auth.php`:
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ return [
 ];
 ```
 
-or by calling `WebAuth::withAuthUrl()` method
+or by calling `Yiisoft\User\Method\WebAuth::withAuthUrl()` method
 
 ```php
 use Yiisoft\User\Method\WebAuth;
@@ -238,7 +238,7 @@ return [
 #### ApiAuth
 
 `Yiisoft\User\Method\ApiAuth` is used to authenticate users in the API clients.
-If authentication is failed, it returns the response from the `Authentication::authenticationFailureHandler()` method.
+If authentication is failed, it returns the response from the `Yiisoft\Auth\Middleware\Authentication::authenticationFailureHandler` handler.
 
 In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI configuration
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,8 @@ $authenticationMethod = new WebAuth();
 $authenticationMethod = $authenticationMethod->withAuthUrl('/auth');
 ```
 
-or in the DI container:
+or in the [DI container](https://github.com/yiisoft/di):
 
->[yiisoft/di](https://github.com/yiisoft/di) configuration example
 ```php
 // config/web/di/auth.php
 return [
@@ -233,7 +232,7 @@ return [
 ];
 ```
 
-In case the application is used along with the [yiisoft/config](https://github.com/yiisoft/config), the package is [configured](./config/di-web.php)
+If the application is used along with the [yiisoft/config](https://github.com/yiisoft/config), the package is [configured](./config/di-web.php)
 automatically to use `WebAuth` as default implementation of `Yiisoft\Auth\AuthenticationMethodInterface`.
 
 #### ApiAuth
@@ -241,7 +240,7 @@ automatically to use `WebAuth` as default implementation of `Yiisoft\Auth\Authen
 `ApiAuth` is used to authenticate users in the API clients.
 If authentication is failed, it returns the response from the `Yiisoft\Auth\Middleware\Authentication::authenticationFailureHandler` handler.
 
-To use `ApiAuth` as an authentication method, you need or provide the `ApiAuth` instance to the `Yiisoft\Auth\Middleware\Authentication` middleware
+To use `ApiAuth` as an authentication method, you need or provide the `ApiAuth` instance to the `Yiisoft\Auth\Middleware\Authentication` middleware:
 
 ```php
 use Yiisoft\Auth\Middleware\Authentication;
@@ -255,9 +254,8 @@ $middleware = new Authentication(
 );
 ```
 
-of to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI container configuration:
+of to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the [DI container](https://github.com/yiisoft/di) configuration:
 
->[yiisoft/di](https://github.com/yiisoft/di) configuration example
 ```php
 // config/web/di/auth.php
 use Yiisoft\Auth\AuthenticationMethodInterface;

--- a/README.md
+++ b/README.md
@@ -190,12 +190,74 @@ The `Yiisoft\User\CurrentUser` instance is stateful, so when you build long-runn
 with tools like [Swoole](https://www.swoole.co.uk/) or [RoadRunner](https://roadrunner.dev/) you should reset
 the state at every request. For this purpose, you can use the `clear()` method.
 
+### Authentication methods
+
+This package provides two authentication methods, `ApiAuth` and `WebAuth`, that implement `AuthenticationMethodInterface`. Both can be provided to the `Yiisoft\Auth\Middleware\Authentication` middleware as authentication method.
+
+#### WebAuth
+
+`Yiisoft\User\Method\WebAuth` is used to authenticate users in the classic web applications.
+If authentication is failed, it creates a new instance of the response from the `Authentication::authenticationFailureHandler`, and adds a `Location` header with a temporary redirect to the authentication URL, by default `/login`.
+
+You can change this behavior through the parameter `authUrl` of the `yiisoft/user` package configuration
+
+```
+return [
+    'yiisoft/user' => [
+        'authUrl' => '/auth',
+        ],
+    ],
+];
+```
+
+or by calling `WebAuth::withAuthUrl()` method
+
+```
+$authenticationMethod = new \Yiisoft\User\Method\WebAuth();
+
+// Returns a new instance with the specified authentication URL.
+$authenticationMethod = $authenticationMethod->withAuthUrl('/auth');
+```
+
+Class `Yiisoft\User\Method\WebAuth` is configured as default implementation of `AuthenticationMethodInterface`.
+
+```
+return [
+    AuthenticationMethodInterface::class => WebAuth::class,
+];
+```
+
+#### ApiAuth
+
+`Yiisoft\User\Method\ApiAuth` is used to authenticate users in the API clients.
+If authentication is failed, it returns the response from the `Authentication::authenticationFailureHandler()` method.
+
+In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `AuthenticationMethodInterface` in the DI configuration
+
+```
+return [
+    AuthenticationMethodInterface::class => ApiAuth::class,
+];
+```
+
+or provide `Yiisoft\User\Method\ApiAuth` instance to the `Yiisoft\Auth\Middleware\Authentication` middleware
+
+```
+$authenticationMethod = new \Yiisoft\User\Method\ApiAuth();
+
+$middleware = new \Yiisoft\Auth\Middleware\Authentication(
+    $authenticationMethod,
+    $responseFactory // PSR-17 ResponseFactoryInterface
+);
+```
+
+For more information about the authentication middleware and authentication methods, see the [yiisoft/auth](https://github.com/yiisoft/auth).
+
 ### Auto login through identity from request attribute
 
 For auto login, you can use the `Yiisoft\User\Login\LoginMiddleware`. This middleware automatically logs user
 in if `Yiisoft\Auth\IdentityInterface` instance presents in a request attribute. It is usually put there by
-`Yiisoft\Auth\Middleware\Authentication`. For more information about the authentication middleware and
-authentication methods, see the [yiisoft/auth](https://github.com/yiisoft/auth).
+`Yiisoft\Auth\Middleware\Authentication`.
 
 > Please note that `Yiisoft\Auth\Middleware\Authentication` should be located before
 > `Yiisoft\User\Login\LoginMiddleware` in the middleware stack.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ return [
 `Yiisoft\User\Method\ApiAuth` is used to authenticate users in the API clients.
 If authentication is failed, it returns the response from the `Yiisoft\Auth\Middleware\Authentication::authenticationFailureHandler` handler.
 
-In order to use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI container configuration
+To use `Yiisoft\User\Method\ApiAuth` as an authentication method, you need to define it as an implementation of `Yiisoft\Auth\AuthenticationMethodInterface` in the DI container configuration
 
 `config/web/di/auth.php`:
 

--- a/config/di-web.php
+++ b/config/di-web.php
@@ -9,6 +9,7 @@ use Yiisoft\User\Guest\GuestIdentityFactoryInterface;
 use Yiisoft\User\Login\Cookie\CookieLogin;
 use Yiisoft\User\Login\Cookie\CookieLoginMiddleware;
 use Yiisoft\User\Method\WebAuth;
+use Yiisoft\User\UserAuth;
 
 /** @var array $params */
 
@@ -19,6 +20,9 @@ return [
         },
     ],
 
+    UserAuth::class => [
+        'withAuthUrl()' => [$params['yiisoft/user']['authUrl']],
+    ],
     WebAuth::class => [
         'withAuthUrl()' => [$params['yiisoft/user']['authUrl']],
     ],

--- a/config/di-web.php
+++ b/config/di-web.php
@@ -8,7 +8,7 @@ use Yiisoft\User\Guest\GuestIdentityFactory;
 use Yiisoft\User\Guest\GuestIdentityFactoryInterface;
 use Yiisoft\User\Login\Cookie\CookieLogin;
 use Yiisoft\User\Login\Cookie\CookieLoginMiddleware;
-use Yiisoft\User\UserAuth;
+use Yiisoft\User\Method\WebAuth;
 
 /** @var array $params */
 
@@ -19,12 +19,11 @@ return [
         },
     ],
 
-    UserAuth::class => [
-        'class' => UserAuth::class,
+    WebAuth::class => [
         'withAuthUrl()' => [$params['yiisoft/user']['authUrl']],
     ],
 
-    AuthenticationMethodInterface::class => UserAuth::class,
+    AuthenticationMethodInterface::class => WebAuth::class,
     GuestIdentityFactoryInterface::class => GuestIdentityFactory::class,
 
     CookieLoginMiddleware::class => [

--- a/src/Method/ApiAuth.php
+++ b/src/Method/ApiAuth.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\User\Method;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Yiisoft\Auth\AuthenticationMethodInterface;
+use Yiisoft\Auth\IdentityInterface;
+use Yiisoft\User\CurrentUser;
+
+/**
+ * Implementation of the `AuthenticationMethodInterface` for authenticating users in the API clients.
+ */
+final class ApiAuth implements AuthenticationMethodInterface
+{
+    public function __construct(private CurrentUser $currentUser)
+    {
+    }
+
+    public function authenticate(ServerRequestInterface $request): ?IdentityInterface
+    {
+        if ($this->currentUser->isGuest()) {
+            return null;
+        }
+
+        return $this->currentUser->getIdentity();
+    }
+
+    public function challenge(ResponseInterface $response): ResponseInterface
+    {
+        return $response;
+    }
+}

--- a/src/Method/ApiAuth.php
+++ b/src/Method/ApiAuth.php
@@ -15,7 +15,7 @@ use Yiisoft\User\CurrentUser;
  */
 final class ApiAuth implements AuthenticationMethodInterface
 {
-    public function __construct(private CurrentUser $currentUser)
+    public function __construct(private readonly CurrentUser $currentUser)
     {
     }
 

--- a/src/Method/WebAuth.php
+++ b/src/Method/WebAuth.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\User;
+namespace Yiisoft\User\Method;
 
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -10,13 +10,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Yiisoft\Auth\AuthenticationMethodInterface;
 use Yiisoft\Auth\IdentityInterface;
 use Yiisoft\Http\Status;
+use Yiisoft\User\CurrentUser;
 
 /**
- * Implementation of the authentication interface for the user.
- *
- * @deprecated Use {@see \Yiisoft\User\Method\WebAuth}. Will remove in the next major version.
+ * Implementation of the `AuthenticationMethodInterface` for authenticating users in the web applications.
  */
-final class UserAuth implements AuthenticationMethodInterface
+final class WebAuth implements AuthenticationMethodInterface
 {
     private string $authUrl = '/login';
 

--- a/src/Method/WebAuth.php
+++ b/src/Method/WebAuth.php
@@ -19,8 +19,10 @@ final class WebAuth implements AuthenticationMethodInterface
 {
     private string $authUrl = '/login';
 
-    public function __construct(private CurrentUser $currentUser, private ResponseFactoryInterface $responseFactory)
-    {
+    public function __construct(
+        private readonly CurrentUser $currentUser,
+        private readonly ResponseFactoryInterface $responseFactory
+    ){
     }
 
     public function authenticate(ServerRequestInterface $request): ?IdentityInterface

--- a/src/Method/WebAuth.php
+++ b/src/Method/WebAuth.php
@@ -22,7 +22,7 @@ final class WebAuth implements AuthenticationMethodInterface
     public function __construct(
         private readonly CurrentUser $currentUser,
         private readonly ResponseFactoryInterface $responseFactory
-    ){
+    ) {
     }
 
     public function authenticate(ServerRequestInterface $request): ?IdentityInterface

--- a/src/UserAuth.php
+++ b/src/UserAuth.php
@@ -14,7 +14,7 @@ use Yiisoft\Http\Status;
 /**
  * Implementation of the authentication interface for the user.
  *
- * @deprecated Use {@see \Yiisoft\User\Method\WebAuth}. Will remove in the next major version.
+ * @deprecated Use {@see \Yiisoft\User\Method\WebAuth}. This class will be removed in the next major version.
  */
 final class UserAuth implements AuthenticationMethodInterface
 {

--- a/tests/ApiAuthTest.php
+++ b/tests/ApiAuthTest.php
@@ -22,7 +22,7 @@ final class ApiAuthTest extends TestCase
     {
         $user = $this->createCurrentUser();
         $user->login(new MockIdentity('test-id'));
-        $result = (new ApiAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+        $result = (new ApiAuth($user))->authenticate(new ServerRequest());
 
         $this->assertNotNull($result);
         $this->assertSame('test-id', $result->getId());
@@ -31,7 +31,7 @@ final class ApiAuthTest extends TestCase
     public function testIdentityNotAuthenticated(): void
     {
         $user = $this->createCurrentUser();
-        $result = (new ApiAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+        $result = (new ApiAuth($user))->authenticate(new ServerRequest());
 
         $this->assertNull($result);
     }
@@ -40,7 +40,7 @@ final class ApiAuthTest extends TestCase
     {
         $response = new Response(Status::UNAUTHORIZED);
         $user = $this->createCurrentUser();
-        $challenge = (new ApiAuth($user, new ResponseFactory()))->challenge($response);
+        $challenge = (new ApiAuth($user))->challenge($response);
 
         $this->assertSame(Status::UNAUTHORIZED, $challenge->getStatusCode());
     }

--- a/tests/ApiAuthTest.php
+++ b/tests/ApiAuthTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\User\Tests;
+
+use HttpSoft\Message\Response;
+use HttpSoft\Message\ResponseFactory;
+use HttpSoft\Message\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Http\Status;
+use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
+use Yiisoft\User\Tests\Support\MockArraySessionStorage;
+use Yiisoft\User\Tests\Support\MockIdentity;
+use Yiisoft\User\Tests\Support\MockIdentityRepository;
+use Yiisoft\User\CurrentUser;
+use Yiisoft\User\Method\ApiAuth;
+
+final class ApiAuthTest extends TestCase
+{
+    public function testSuccessfulAuthentication(): void
+    {
+        $user = $this->createCurrentUser();
+        $user->login(new MockIdentity('test-id'));
+        $result = (new ApiAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+
+        $this->assertNotNull($result);
+        $this->assertSame('test-id', $result->getId());
+    }
+
+    public function testIdentityNotAuthenticated(): void
+    {
+        $user = $this->createCurrentUser();
+        $result = (new ApiAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+
+        $this->assertNull($result);
+    }
+
+    public function testChallengeIsCorrect(): void
+    {
+        $response = new Response(Status::UNAUTHORIZED);
+        $user = $this->createCurrentUser();
+        $challenge = (new ApiAuth($user, new ResponseFactory()))->challenge($response);
+
+        $this->assertSame(Status::UNAUTHORIZED, $challenge->getStatusCode());
+    }
+
+    private function createCurrentUser(): CurrentUser
+    {
+        return (new CurrentUser(new MockIdentityRepository(), new SimpleEventDispatcher()))
+            ->withSession(new MockArraySessionStorage());
+    }
+}

--- a/tests/ApiAuthTest.php
+++ b/tests/ApiAuthTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\User\Tests;
 
 use HttpSoft\Message\Response;
-use HttpSoft\Message\ResponseFactory;
 use HttpSoft\Message\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Http\Status;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -23,7 +23,7 @@ use Yiisoft\User\Login\Cookie\CookieLogin;
 use Yiisoft\User\Login\Cookie\CookieLoginMiddleware;
 use Yiisoft\User\Login\LoginMiddleware;
 use Yiisoft\User\Tests\Support\MockIdentityRepository;
-use Yiisoft\User\UserAuth;
+use Yiisoft\User\Method\WebAuth;
 
 use function dirname;
 
@@ -37,10 +37,10 @@ final class ConfigTest extends TestCase
         $this->assertInstanceOf(GuestIdentityFactory::class, $container->get(GuestIdentityFactoryInterface::class));
         $this->assertInstanceOf(LoginMiddleware::class, $container->get(LoginMiddleware::class));
 
-        $userAuth = $container->get(AuthenticationMethodInterface::class);
+        $webAuth = $container->get(AuthenticationMethodInterface::class);
 
-        $this->assertInstanceOf(UserAuth::class, $userAuth);
-        $this->assertSame('/login', $this->getInaccessibleProperty($userAuth, 'authUrl'));
+        $this->assertInstanceOf(WebAuth::class, $webAuth);
+        $this->assertSame('/login', $this->getInaccessibleProperty($webAuth, 'authUrl'));
 
         $cookieLogin = $container->get(CookieLogin::class);
 
@@ -67,10 +67,10 @@ final class ConfigTest extends TestCase
             ],
         ]);
 
-        $userAuth = $container->get(AuthenticationMethodInterface::class);
+        $webAuth = $container->get(AuthenticationMethodInterface::class);
 
-        $this->assertInstanceOf(UserAuth::class, $userAuth);
-        $this->assertSame('/override', $this->getInaccessibleProperty($userAuth, 'authUrl'));
+        $this->assertInstanceOf(WebAuth::class, $webAuth);
+        $this->assertSame('/override', $this->getInaccessibleProperty($webAuth, 'authUrl'));
 
         $cookieLogin = $container->get(CookieLogin::class);
 

--- a/tests/UserAuthTest.php
+++ b/tests/UserAuthTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\User\Tests;
+
+use HttpSoft\Message\Response;
+use HttpSoft\Message\ResponseFactory;
+use HttpSoft\Message\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Http\Status;
+use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
+use Yiisoft\User\Tests\Support\MockArraySessionStorage;
+use Yiisoft\User\Tests\Support\MockIdentity;
+use Yiisoft\User\Tests\Support\MockIdentityRepository;
+use Yiisoft\User\CurrentUser;
+use Yiisoft\User\UserAuth;
+
+final class UserAuthTest extends TestCase
+{
+    public function testSuccessfulAuthentication(): void
+    {
+        $user = $this->createCurrentUser();
+        $user->login(new MockIdentity('test-id'));
+        $result = (new UserAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+
+        $this->assertNotNull($result);
+        $this->assertSame('test-id', $result->getId());
+    }
+
+    public function testIdentityNotAuthenticated(): void
+    {
+        $user = $this->createCurrentUser();
+        $result = (new UserAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+
+        $this->assertNull($result);
+    }
+
+    public function testChallengeIsCorrect(): void
+    {
+        $response = new Response();
+        $user = $this->createCurrentUser();
+        $challenge = (new UserAuth($user, new ResponseFactory()))->challenge($response);
+
+        $this->assertSame(Status::FOUND, $challenge->getStatusCode());
+        $this->assertSame('/login', $challenge->getHeaderLine('Location'));
+    }
+
+    public function testCustomAuthUrl(): void
+    {
+        $response = new Response();
+        $user = $this->createCurrentUser();
+        $challenge = (new UserAuth($user, new ResponseFactory()))
+            ->withAuthUrl('/custom-auth-url')
+            ->challenge($response);
+
+        $this->assertSame('/custom-auth-url', $challenge->getHeaderLine('Location'));
+    }
+
+    public function testImmutability(): void
+    {
+        $original = new UserAuth($this->createCurrentUser(), new ResponseFactory());
+
+        $this->assertNotSame($original, $original->withAuthUrl('/custom-auth-url'));
+    }
+
+    private function createCurrentUser(): CurrentUser
+    {
+        return (new CurrentUser(new MockIdentityRepository(), new SimpleEventDispatcher()))
+            ->withSession(new MockArraySessionStorage());
+    }
+}

--- a/tests/WebAuthTest.php
+++ b/tests/WebAuthTest.php
@@ -14,15 +14,15 @@ use Yiisoft\User\Tests\Support\MockArraySessionStorage;
 use Yiisoft\User\Tests\Support\MockIdentity;
 use Yiisoft\User\Tests\Support\MockIdentityRepository;
 use Yiisoft\User\CurrentUser;
-use Yiisoft\User\UserAuth;
+use Yiisoft\User\Method\WebAuth;
 
-final class UserAuthTest extends TestCase
+final class WebAuthTest extends TestCase
 {
     public function testSuccessfulAuthentication(): void
     {
         $user = $this->createCurrentUser();
         $user->login(new MockIdentity('test-id'));
-        $result = (new UserAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+        $result = (new WebAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
 
         $this->assertNotNull($result);
         $this->assertSame('test-id', $result->getId());
@@ -31,7 +31,7 @@ final class UserAuthTest extends TestCase
     public function testIdentityNotAuthenticated(): void
     {
         $user = $this->createCurrentUser();
-        $result = (new UserAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
+        $result = (new WebAuth($user, new ResponseFactory()))->authenticate(new ServerRequest());
 
         $this->assertNull($result);
     }
@@ -40,7 +40,7 @@ final class UserAuthTest extends TestCase
     {
         $response = new Response();
         $user = $this->createCurrentUser();
-        $challenge = (new UserAuth($user, new ResponseFactory()))->challenge($response);
+        $challenge = (new WebAuth($user, new ResponseFactory()))->challenge($response);
 
         $this->assertSame(Status::FOUND, $challenge->getStatusCode());
         $this->assertSame('/login', $challenge->getHeaderLine('Location'));
@@ -50,7 +50,7 @@ final class UserAuthTest extends TestCase
     {
         $response = new Response();
         $user = $this->createCurrentUser();
-        $challenge = (new UserAuth($user, new ResponseFactory()))
+        $challenge = (new WebAuth($user, new ResponseFactory()))
             ->withAuthUrl('/custom-auth-url')
             ->challenge($response);
 
@@ -59,7 +59,7 @@ final class UserAuthTest extends TestCase
 
     public function testImmutability(): void
     {
-        $original = new UserAuth($this->createCurrentUser(), new ResponseFactory());
+        $original = new WebAuth($this->createCurrentUser(), new ResponseFactory());
 
         $this->assertNotSame($original, $original->withAuthUrl('/custom-auth-url'));
     }


### PR DESCRIPTION
rename UserAuth to WebAuth
add ApiAuth

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️/❌ has deprecated class

#101 