### PR TITLE
Bump `yiisoft/session` version to `^3.0.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #120: Explicitly import classes and constants in "use" section (@vjik)
 - Enh #127: Bump `yiisoft/auth` version to `^3.3.0`, and fix deprecated classes usage (@klsoft-web, @vjik)
+- Enh #132: Bump `yiisoft/session` version to `^3.0.2` (@vjik)
 
 ## 2.3.2 December 23, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "yiisoft/access": "^2.0",
         "yiisoft/auth": "^3.3.0",
         "yiisoft/cookies": "^1.2",
-        "yiisoft/session": "^1.0 || ^2.0 || ^3.0",
+        "yiisoft/session": "^3.0.2",
         "yiisoft/http": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
Fix #124 
